### PR TITLE
Expose the config schema as an application

### DIFF
--- a/lib/api-v1/model.js
+++ b/lib/api-v1/model.js
@@ -12,6 +12,7 @@ import ajv_formats from "ajv-formats";
 import {DB} from "@amrc-factoryplus/utilities";
 
 import {App, Class, Null_UUID, Service} from "../constants.js";
+import { Specials } from "./special.js";
 
 const DB_Version = 6;
 
@@ -24,32 +25,6 @@ const Immutable = new Set([
     Class.Device,
     Class.Schema,
 ]);
-
-class ObjectRegistration {
-    constructor(model) {
-        this.model = model;
-    }
-
-    async list() {
-        return await this.model.object_list();
-    }
-
-    async get(obj) {
-        const klass = await this.model.object_class(obj);
-        if (klass == null) return null;
-        return {"class": klass};
-    }
-
-    async put(obj, json) {
-        const klass = json?.class;
-        if (klass == null) return 400;
-        return await this.model.object_set_class(obj, klass);
-    }
-
-    async delete(obj) {
-        return 405;
-    }
-}
 
 /* XXX These should be methods on a query object or something... */
 async function _q_row(query, sql, params) {
@@ -85,7 +60,8 @@ export default class Model extends EventEmitter {
     async init() {
         await this.db.init();
 
-        this.special.set(App.Registration, new ObjectRegistration(this));
+        for (const Sp of Specials)
+            this.special.set(Sp.application, new Sp(this));
 
         return this;
     }
@@ -382,7 +358,7 @@ export default class Model extends EventEmitter {
 
             const schema = await this.find_schema(query, appid);
             if (schema && !schema(json))
-                return 403;
+                return 422;
 
             json = JSON.stringify(json);
 
@@ -476,6 +452,16 @@ export default class Model extends EventEmitter {
         const schema = this.ajv.compile(schema_text);
         this.schemas.set(app, schema);
         return schema;
+    }
+
+    async app_schema_list () {
+        const dbr = await this.db.query(`
+            select o.uuid
+            from app a
+                join object o on o.id = a.id
+            where a.schema is not null
+        `);
+        return dbr.rows.map(r => r.uuid);
     }
 
     app_schema(app) {

--- a/lib/api-v1/model.js
+++ b/lib/api-v1/model.js
@@ -505,7 +505,7 @@ export default class Model extends EventEmitter {
                 where id = $1
             `, [app_id, schema]);
 
-            this.schemas.set(app, validate);
+            this.schemas.set(app_id, validate);
             this.emit("change", {app});
             return true;
         });

--- a/lib/api-v1/special.js
+++ b/lib/api-v1/special.js
@@ -1,0 +1,70 @@
+/*
+ * Factory+ / AMRC Connectivity Stack (ACS) Config Store component
+ * Special Applications
+ * Copyright 2021 AMRC
+ */
+
+import { App } from "../constants.js";
+
+class SpecialApp {
+    constructor (model) {
+        this.model = model;
+    }
+}
+
+class ObjectRegistration extends SpecialApp {
+    static application = App.Registration;
+
+    list () {
+        return this.model.object_list();
+    }
+
+    async get(obj) {
+        const klass = await this.model.object_class(obj);
+        if (klass == null) return null;
+        return {"class": klass};
+    }
+
+    async put(obj, json) {
+        const klass = json?.class;
+        if (klass == null) return 400;
+        return await this.model.object_set_class(obj, klass);
+    }
+
+    async delete(obj) {
+        return 405;
+    }
+}
+
+class ConfigSchema extends SpecialApp {
+    static application = App.ConfigSchema;
+
+    list () {
+        return this.model.app_schema_list();
+    }
+
+    async get (obj) {
+        const rv = await this.model.app_schema(obj);
+        return rv?.schema;
+    }
+
+    async put (obj, json) {
+        const rv = await this.model.app_schema_update(obj, json);
+        
+        if (rv === null)
+            return 422;
+        else if (rv === true)
+            return 204;
+        else if (rv === false)
+            /* XXX Properly we should distinguish here between 404 for
+             * object-not-found and 405 for object-is-not-an-app. */
+            return 405;
+        else
+            /* XXX The /config-schema endpoint returned a list of
+             * conflicting objects, which we now throw away. This
+             * convention could be generalised? */
+            return 409;
+    }
+}
+
+export const Specials = [ObjectRegistration, ConfigSchema];

--- a/lib/api-v1/special.js
+++ b/lib/api-v1/special.js
@@ -10,6 +10,9 @@ class SpecialApp {
     constructor (model) {
         this.model = model;
     }
+
+    put (obj, json) { return 405; }
+    delete (obj) { return 405; }
 }
 
 class ObjectRegistration extends SpecialApp {
@@ -29,10 +32,6 @@ class ObjectRegistration extends SpecialApp {
         const klass = json?.class;
         if (klass == null) return 400;
         return await this.model.object_set_class(obj, klass);
-    }
-
-    async delete(obj) {
-        return 405;
     }
 }
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -20,6 +20,7 @@ export const App = {
     Registration: "cb40bed5-49ad-4443-a7f5-08c75009da8f",
     Info: "64a8bfa9-7772-45c4-9d1a-9e6290690957",
     SparkplugAddress: "8e32801b-f35a-4cbf-a5c3-2af64d3debd7",
+    ConfigSchema: "dbd8a535-52ba-4f6e-b4f8-9b71aefe09d3",
 };
 
 export const Schema = {


### PR DESCRIPTION
Expose the JSON schema for an application as an application in its own right.

This makes it possible to edit the config schema through the editor interface, and to load config schemas in from dump files.