### PR TITLE
Support ETags on config entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 pkgver!=node -e 'console.log(JSON.parse(fs.readFileSync("package.json")).version)'
 
-version?=${pkgver}
+version?=v${pkgver}
 suffix?=
 registry?=ghcr.io/amrc-factoryplus
 repo?=acs-configdb

--- a/lib/api-v1/controller.js
+++ b/lib/api-v1/controller.js
@@ -8,6 +8,8 @@ import express from "express";
 
 import {Debug, UUIDs} from "@amrc-factoryplus/utilities";
 
+import * as etags from "../etags.js";
+
 import {App, Class} from "../constants.js";
 import Model from "./model.js";
 
@@ -280,8 +282,9 @@ export default class API {
 
         let entry = await this.model.config_get(req.params);
 
-        if (entry == null)
-            return res.status(404).end();
+        const etst = etags.checker(req)(entry?.etag);
+        if (etst) return res.status(etst).end();
+        if (entry == null) return res.status(404).end();
 
         res.status(200);
         if (entry.etag) res.header("ETag", `"${entry.etag}"`);
@@ -299,7 +302,8 @@ export default class API {
          * the database normalises the JSON so we can't guarantee that.
          * A PUT ETag is only useful for If-Match, and a weak etag can't
          * be used for that. */
-        let st = await this.model.config_put(req.params, req.body);
+        let st = await this.model.config_put(req.params, req.body,
+            etags.checker(req));
         /* PUT can't return 304 */
         res.status(st == 304 ? 204 : st).send();
     }
@@ -309,7 +313,8 @@ export default class API {
             req.params.app, true);
         if (!ok) return res.status(403).end();
 
-        let st = await this.model.config_delete(req.params);
+        let st = await this.model.config_delete(req.params,
+            etags.checker(req));
         res.status(st).end();
     }
 
@@ -324,7 +329,8 @@ export default class API {
         if (ok.includes(false))
             return res.status(403).end();
 
-        const st = await this.model.config_merge_patch(req.params, req.body);
+        const st = await this.model.config_merge_patch(req.params, req.body,
+            etags.checker(req));
         res.status(st).send();
     }
 

--- a/lib/api-v1/controller.js
+++ b/lib/api-v1/controller.js
@@ -161,7 +161,7 @@ export default class API {
 
         const info = await this.model.config_get(
             {app: App.Info, object: uuid});
-        const name = info?.name ?? "";
+        const name = info?.json?.name ?? "";
 
         res.status(200).json({uuid, name});
     }
@@ -278,12 +278,14 @@ export default class API {
             req.params.app, true);
         if (!ok) return res.status(403).end();
 
-        let json = await this.model.config_get(req.params);
+        let entry = await this.model.config_get(req.params);
 
-        if (json == null)
-            res.status(404).end();
-        else
-            res.status(200).json(json);
+        if (entry == null)
+            return res.status(404).end();
+
+        res.status(200);
+        if (entry.etag) res.header("ETag", `"${entry.etag}"`);
+        res.json(entry.json);
     }
 
     async config_put(req, res) {
@@ -291,6 +293,12 @@ export default class API {
             req.params.app, true);
         if (!ok) return res.status(403).end();
 
+        /* Do not attempt to set an etag on a PUT response. We can only
+         * do this (with a strong etag) if we guarantee that the stored
+         * entity is byte-for-byte identical to the submitted entity;
+         * the database normalises the JSON so we can't guarantee that.
+         * A PUT ETag is only useful for If-Match, and a weak etag can't
+         * be used for that. */
         let st = await this.model.config_put(req.params, req.body);
         res.status(st).send();
     }

--- a/lib/api-v1/controller.js
+++ b/lib/api-v1/controller.js
@@ -300,7 +300,8 @@ export default class API {
          * A PUT ETag is only useful for If-Match, and a weak etag can't
          * be used for that. */
         let st = await this.model.config_put(req.params, req.body);
-        res.status(st).send();
+        /* PUT can't return 304 */
+        res.status(st == 304 ? 204 : st).send();
     }
 
     async config_delete(req, res) {

--- a/lib/api-v1/controller.js
+++ b/lib/api-v1/controller.js
@@ -283,6 +283,10 @@ export default class API {
         let entry = await this.model.config_get(req.params);
 
         const etst = etags.checker(req)(entry?.etag);
+        if (etst == 412) {
+            if (entry) res.header("ETag", `"${entry.etag}"`)
+            return res.status(304).end();
+        }
         if (etst) return res.status(etst).end();
         if (entry == null) return res.status(404).end();
 
@@ -304,8 +308,7 @@ export default class API {
          * be used for that. */
         let st = await this.model.config_put(req.params, req.body,
             etags.checker(req));
-        /* PUT can't return 304 */
-        res.status(st == 304 ? 204 : st).send();
+        res.status(st).send();
     }
 
     async config_delete(req, res) {

--- a/lib/api-v1/model.js
+++ b/lib/api-v1/model.js
@@ -391,7 +391,7 @@ export default class Model extends EventEmitter {
         if (rv == 204 || rv == 201)
             this.emit_change(q);
         /* PUT doesn't return 304 */
-        return rv;
+        return rv == 304 ? 204 : rv;
     }
 
     async config_delete(q, check_etag) {

--- a/lib/api-v1/model.js
+++ b/lib/api-v1/model.js
@@ -344,10 +344,6 @@ export default class Model extends EventEmitter {
         const special = this.special.get(q.app);
         if (special) return await special.put(q.object, json);
 
-        const overwrite = q.exclusive
-            ? `do nothing`
-            : `do update set json = excluded.json, etag = default`;
-
         const rv = await this.db.txn({}, async query => {
             const appid = await this._app_id(query, q.app);
             if (appid == null) return 404;
@@ -359,18 +355,35 @@ export default class Model extends EventEmitter {
 
             json = JSON.stringify(json);
 
-            let ok = await query(`
+            const conf = await _q_row(query, `
+                select id from config
+                where app = $1 and object = $2
+            `, [appid, objid]);
+
+            if (conf) {
+                if (q.exclusive) return 409;
+
+                const ok = await query(`
+                    update config as c
+                    set json = $2, etag = default
+                    where id = $1 and json != $2
+                    returning 1 ok
+                `, [conf.id, json]);
+
+                return ok.rowCount == 0 ? 304 : 204;
+            }
+
+            await query(`
                 insert into config (app, object, json)
                 values ($1, $2, $3)
-                on conflict (app, object) ${overwrite}
-                returning 1 ok
             `, [appid, objid, json]);
 
-            return ok.rowCount == 0 ? 409 : 204;
+            return 201;
         });
 
-        if (rv == 204)
+        if (rv == 204 || rv == 201)
             this.emit_change(q);
+        /* PUT doesn't return 304 */
         return rv;
     }
 

--- a/lib/api-v1/model.js
+++ b/lib/api-v1/model.js
@@ -15,7 +15,7 @@ import {Debug, DB} from "@amrc-factoryplus/utilities";
 import {App, Class, Null_UUID, Service} from "../constants.js";
 import { Specials } from "./special.js";
 
-const DB_Version = 6;
+const DB_Version = 7;
 
 const Immutable = new Set([
     Null_UUID,
@@ -325,10 +325,11 @@ export default class Model extends EventEmitter {
 
     async config_get(q) {
         const special = this.special.get(q.app)
-        if (special) return await special.get(q.object);
+        if (special)
+            return await special.get(q.object);
 
         let dbr = await this.db.query(`
-            select c.json
+            select c.json, c.etag
             from config c
                 join object a on a.id = c.app
                 join object o on o.id = c.object
@@ -336,7 +337,7 @@ export default class Model extends EventEmitter {
                 and o.uuid = $2
         `, [q.app, q.object]);
 
-        return dbr.rows[0]?.json;
+        return dbr.rows[0];
     }
 
     async config_put(q, json) {
@@ -345,7 +346,7 @@ export default class Model extends EventEmitter {
 
         const overwrite = q.exclusive
             ? `do nothing`
-            : `do update set json = excluded.json`;
+            : `do update set json = excluded.json, etag = default`;
 
         const rv = await this.db.txn({}, async query => {
             const appid = await this._app_id(query, q.app);
@@ -402,11 +403,12 @@ export default class Model extends EventEmitter {
 
         /* Safety check: applying a merge-patch to a non-object destroys
          * the whole thing. */
-        if (typeof(conf) != "object" || Array.isArray(conf))
+        const json = conf.json;
+        if (typeof(json) != "object" || Array.isArray(json))
             return 409;
 
-        const nconf = merge_patch.apply(conf, patch);
-        console.log("PATCH: source: %o", conf);
+        const nconf = merge_patch.apply(json, patch);
+        console.log("PATCH: source: %o", json);
         console.log("PATCH: patch: %o", patch);
         console.log("PATCH: result: %o", nconf);
         return await this.config_put(q, nconf);

--- a/lib/api-v1/model.js
+++ b/lib/api-v1/model.js
@@ -340,7 +340,8 @@ export default class Model extends EventEmitter {
         return dbr.rows[0];
     }
 
-    async config_put(q, json) {
+    async config_put(q, json, check_etag) {
+        /* XXX specials currently don't support etags */
         const special = this.special.get(q.app);
         if (special) return await special.put(q.object, json);
 
@@ -350,15 +351,21 @@ export default class Model extends EventEmitter {
             const objid = await this._obj_id(query, q.object);
             if (objid == null) return 404;
 
+            const conf = await _q_row(query, `
+                select id, etag 
+                from config
+                where app = $1 and object = $2
+            `, [appid, objid]);
+
+            if (check_etag) {
+                const etst = check_etag(conf?.etag);
+                if (etst) return etst;
+            }
+
             const schema = await this.find_schema(query, appid);
             if (schema && !schema(json)) return 422;
 
             json = JSON.stringify(json);
-
-            const conf = await _q_row(query, `
-                select id from config
-                where app = $1 and object = $2
-            `, [appid, objid]);
 
             if (conf) {
                 if (q.exclusive) return 409;
@@ -387,31 +394,47 @@ export default class Model extends EventEmitter {
         return rv;
     }
 
-    async config_delete(q) {
+    async config_delete(q, check_etag) {
         const special = this.special.get(q.app);
         if (special) return await special.delete(q.object);
 
-        let ok = await this.db.query(`
-            delete from config c
-            using object a, object o, app
-            where a.id = app.id
-                and a.uuid = $1
-                and o.uuid = $2
-                and c.app = a.id
-                and c.object = o.id
-            returning 1 ok
-        `, [q.app, q.object]);
+        const rv = await this.db.txn({}, async query => {
+            const conf = await _q_row(query, `
+                select c.id, c.etag
+                from config c
+                    join object a on a.id = c.app
+                    join app on app.id = a.id
+                    join object o on o.id = c.object
+                where a.uuid = $1 and o.uuid = $2
+            `, [q.app, q.object]);
 
-        if (ok.rowCount == 0) return 404;
-        this.emit_change(q);
-        return 204;
+            if (check_etag) {
+                const etst = check_etag(conf?.etag);
+                if (etst) return etst;
+            }
+            if (!conf) return 404;
+
+            await query(`
+                delete from config
+                where id = $1
+            `, [conf.id]);
+            return 204;
+        });
+
+        if (rv == 204) this.emit_change(q);
+        return rv;
     }
 
     /* XXX This does not perform the patch atomically. Properly we
      * should do this all under one transaction, but that would require
      * a substantial rework of the code. */
-    async config_merge_patch (q, patch) {
+    async config_merge_patch (q, patch, check_etag) {
         const conf = await this.config_get(q);
+
+        if (check_etag) {
+            const etst = check_etag(conf?.etag);
+            if (etst) return etst;
+        }
         if (conf == null) return 404;
 
         /* Safety check: applying a merge-patch to a non-object destroys

--- a/lib/api-v1/special.js
+++ b/lib/api-v1/special.js
@@ -15,6 +15,13 @@ class SpecialApp {
     delete (obj) { return 405; }
 }
 
+/* XXX These should work the other way: they should be stored as normal
+ * config entries, and the ConfigDB code should look up what it needs in
+ * the database like everyone else. Then they would get the benefit of
+ * etags and any other future improvements to config handling
+ * (e.g. transactions, ownership, ...).
+ */
+
 class ObjectRegistration extends SpecialApp {
     static application = App.Registration;
 
@@ -25,7 +32,9 @@ class ObjectRegistration extends SpecialApp {
     async get(obj) {
         const klass = await this.model.object_class(obj);
         if (klass == null) return null;
-        return {"class": klass};
+        return {
+            json: {"class": klass},
+        };
     }
 
     async put(obj, json) {
@@ -44,7 +53,8 @@ class ConfigSchema extends SpecialApp {
 
     async get (obj) {
         const rv = await this.model.app_schema(obj);
-        return rv?.schema;
+        if (rv == null) return;
+        return { json: rv.schema };
     }
 
     async put (obj, json) {

--- a/lib/etags.js
+++ b/lib/etags.js
@@ -4,6 +4,11 @@
  * Copyright 2023 AMRC
  */
 
+import {Debug} from "@amrc-factoryplus/utilities";
+
+const debug = new Debug();
+const log = debug.log.bind(debug, "etag");
+
 /* An ETag consists of an opaque string and a type. Currently there are
  * two types: strong and weak. */
 export class ETag {
@@ -21,12 +26,14 @@ export class ETag {
     }
 
     strong_compare (other) {
+        log("Strong comparing %o vs %o", this, other);
         if (this.weak || other.weak)
             return false;
         return this.opaque == other.opaque;
     }
 
     weak_compare (other) {
+        log("Weak comparing %o vs %o", this, other);
         return this.opaque == other.opaque;
     }
 }
@@ -52,28 +59,45 @@ function trim (header) {
 export function check_match_headers (req, opaque, weak) {
     const exists = opaque != null;
     const etag = new ETag(opaque, weak);
+    log("Checking %s against DB etag %o", req.method, etag);
 
     const match = trim(req.header("If-Match"));
+    log("If-Match: %s", match);
     if (match == "*") {
-        if (!exists) return false;
+        if (!exists) {
+            log("If-Match *, no resource");
+            return 412;
+        }
     }
     else if (match != undefined) {
         const tags = parse_etags(match);
-        if (tags == null) return null;
+        log("Checking If-Match etags: %o", tags);
+        if (tags == null) return 400;
         if (!tags.some(t => t.strong_compare(etag)))
-            return false;
+            return 412;
     }
 
     const none = trim(req.header("If-None-Match"));
+    const fail = req.method == "GET" || req.method == "HEAD" ? 304 : 412;
+    log("If-None-Match: %s", none);
     if (none == "*") {
-        if (exists) return false;
+        if (exists) {
+            log("If-None-Match *, existing resource");
+            return fail;
+        }
     }
     else if (none != undefined) {
         const tags = parse_etags(none);
-        if (tags == null) return null;
+        log("Checking If-N-Match etags: %o", tags);
+        if (tags == null) return 400;
         if (tags.some(t => t.weak_compare(etag)))
-            return false;
+            return fail;
     }
 
-    return true;
+    return;
 }
+
+export function checker (req) {
+    return etag => check_match_headers(req, etag);
+}
+

--- a/lib/etags.js
+++ b/lib/etags.js
@@ -26,14 +26,12 @@ export class ETag {
     }
 
     strong_compare (other) {
-        log("Strong comparing %o vs %o", this, other);
         if (this.weak || other.weak)
             return false;
         return this.opaque == other.opaque;
     }
 
     weak_compare (other) {
-        log("Weak comparing %o vs %o", this, other);
         return this.opaque == other.opaque;
     }
 }
@@ -59,35 +57,24 @@ function trim (header) {
 export function check_match_headers (req, opaque, weak) {
     const exists = opaque != null;
     const etag = new ETag(opaque, weak);
-    log("Checking %s against DB etag %o", req.method, etag);
 
     const match = trim(req.header("If-Match"));
-    log("If-Match: %s", match);
     if (match == "*") {
-        if (!exists) {
-            log("If-Match *, no resource");
-            return 412;
-        }
+        if (!exists) return 412;
     }
     else if (match != undefined) {
         const tags = parse_etags(match);
-        log("Checking If-Match etags: %o", tags);
         if (tags == null) return 400;
         if (!tags.some(t => t.strong_compare(etag)))
             return 412;
     }
 
     const none = trim(req.header("If-None-Match"));
-    log("If-None-Match: %s", none);
     if (none == "*") {
-        if (exists) {
-            log("If-None-Match *, existing resource");
-            return 412;
-        }
+        if (exists) return 412;
     }
     else if (none != undefined) {
         const tags = parse_etags(none);
-        log("Checking If-N-Match etags: %o", tags);
         if (tags == null) return 400;
         if (tags.some(t => t.weak_compare(etag)))
             return 412;

--- a/lib/etags.js
+++ b/lib/etags.js
@@ -78,12 +78,11 @@ export function check_match_headers (req, opaque, weak) {
     }
 
     const none = trim(req.header("If-None-Match"));
-    const fail = req.method == "GET" || req.method == "HEAD" ? 304 : 412;
     log("If-None-Match: %s", none);
     if (none == "*") {
         if (exists) {
             log("If-None-Match *, existing resource");
-            return fail;
+            return 412;
         }
     }
     else if (none != undefined) {
@@ -91,7 +90,7 @@ export function check_match_headers (req, opaque, weak) {
         log("Checking If-N-Match etags: %o", tags);
         if (tags == null) return 400;
         if (tags.some(t => t.weak_compare(etag)))
-            return fail;
+            return 412;
     }
 
     return;

--- a/lib/etags.js
+++ b/lib/etags.js
@@ -1,0 +1,79 @@
+/*
+ * Factory+ / AMRC Connectivity Stack (ACS) Config Store component
+ * ETag utility functions
+ * Copyright 2023 AMRC
+ */
+
+/* An ETag consists of an opaque string and a type. Currently there are
+ * two types: strong and weak. */
+export class ETag {
+    constructor (opaque, weak) {
+        this.opaque = opaque;
+        this.weak = weak ?? false;
+    }
+
+    static parse (str) {
+        /* Pattern from RFC7232 sec 2.3 */
+        const match = str.match(/^(W\/)?"([\x21\x23-\x7e\x90-\xff]*)"$/);
+
+        if (!match) return null;
+        return new ETag(match[2], match[1] != undefined);
+    }
+
+    strong_compare (other) {
+        if (this.weak || other.weak)
+            return false;
+        return this.opaque == other.opaque;
+    }
+
+    weak_compare (other) {
+        return this.opaque == other.opaque;
+    }
+}
+
+/* I am not convinced this is entirely correct, but it is equivalent to
+ * what express's fresh module does. This will not correctly handle
+ * etags containing commas, which I think are permitted. */
+function parse_etags (header) {
+    const etags = header.split(/ *, */)
+        .map(tok => ETag.parse(tok));
+    if (etags.includes(null))
+        return null;
+    return etags;
+}
+
+function trim (header) {
+    return header?.replace(/^ *| *$/, "");
+}
+
+/* Check a request against an etag. Pass null to indicate the
+ * resource does not exist. This function does not handle the case of a
+ * resource which exists but has no etag. */
+export function check_match_headers (req, opaque, weak) {
+    const exists = opaque != null;
+    const etag = new ETag(opaque, weak);
+
+    const match = trim(req.header("If-Match"));
+    if (match == "*") {
+        if (!exists) return false;
+    }
+    else if (match != undefined) {
+        const tags = parse_etags(match);
+        if (tags == null) return null;
+        if (!tags.some(t => t.strong_compare(etag)))
+            return false;
+    }
+
+    const none = trim(req.header("If-None-Match"));
+    if (none == "*") {
+        if (exists) return false;
+    }
+    else if (none != undefined) {
+        const tags = parse_etags(none);
+        if (tags == null) return null;
+        if (tags.some(t => t.weak_compare(etag)))
+            return false;
+    }
+
+    return true;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-configdb",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "The Config Store component of the AMRC Connectivity Stack",
   "author": "AMRC",
   "license": "MIT",

--- a/sql/migrate.sql
+++ b/sql/migrate.sql
@@ -19,6 +19,7 @@
 
 -- Version 6 was the first to use this setup.
 \ir v6.sql
+\ir v7.sql
 
 -- Revoke some unhelpful default permissions.
 revoke all on database :"db" from public;

--- a/sql/migration.sql
+++ b/sql/migration.sql
@@ -18,11 +18,11 @@ create or replace procedure migrate_to (newvers integer, sql text)
             if curvers is null or curvers < newvers then
                 raise notice 'Migrating database schema to version %', newvers;
                 execute sql;
-            end if;
-            if curvers is null then
-                insert into version (version) values (newvers);
-            else
-                update version set version = newvers;
+                if curvers is null then
+                    insert into version (version) values (newvers);
+                else
+                    update version set version = newvers;
+                end if;
             end if;
         end;
     $$;

--- a/sql/v7.sql
+++ b/sql/v7.sql
@@ -1,0 +1,8 @@
+-- Factory+ config DB
+-- Database creation/upgrade DDL.
+-- Copyright 2023 AMRC.
+
+call migrate_to(7, $$
+    alter table config
+    add column etag uuid default gen_random_uuid();
+$$);


### PR DESCRIPTION
* Store a revision UUID against each config entry.
* Return this revision UUID as an ETag in the HTTP response.
* Properly support HTTP If-Match and If-None-Match request headers.

Full etag support has a number of applications, which will become more important as we get more services independently updating the ConfigDB. The most important is that a PUT/PATCH/DELETE request can ensure that the correct revision of the config entry is the one being affected by the request. Others include PUT with If-None-Match: * to get exclusive create, and reliable 304 responses for situations where processing (including further lookups) is performed on an entry and we don't want to repeat it unnecessarily.

I am going to update the service spec for the ConfigDB to specify that a config entry etag must take the form of a UUID. This makes some forms of processing easier, for instance an Edge Agent can publish its config file etag so that we can tell if it's running the latest version or not.