### PR TITLE
Accept PATCH to nonexistent configs

### DIFF
--- a/lib/api-v1/controller.js
+++ b/lib/api-v1/controller.js
@@ -334,7 +334,7 @@ export default class API {
 
         const st = await this.model.config_merge_patch(req.params, req.body,
             etags.checker(req));
-        res.status(st).send();
+        res.status(st == 201 ? 204 : st).send();
     }
 
     config_search_parse(query) {

--- a/lib/api-v1/model.js
+++ b/lib/api-v1/model.js
@@ -435,17 +435,19 @@ export default class Model extends EventEmitter {
             const etst = check_etag(conf?.etag);
             if (etst) return etst;
         }
-        if (conf == null) return 404;
+
+        /* This needs to be null, not undefined, for a nonexistent
+         * object, or the 409 test below will fail. */
+        const json = conf?.json ?? null;
+        console.log("PATCH: source: %o", json);
+        console.log("PATCH: patch: %o", patch);
 
         /* Safety check: applying a merge-patch to a non-object destroys
          * the whole thing. */
-        const json = conf.json;
         if (typeof(json) != "object" || Array.isArray(json))
             return 409;
 
         const nconf = merge_patch.apply(json, patch);
-        console.log("PATCH: source: %o", json);
-        console.log("PATCH: patch: %o", patch);
         console.log("PATCH: result: %o", nconf);
         return await this.config_put(q, nconf);
     }


### PR DESCRIPTION
This allows a client to always PATCH, and create the config if necessary.