### PR TITLE
Support YAML in the editor

### DIFF
--- a/editor/editor.js
+++ b/editor/editor.js
@@ -4,12 +4,13 @@
  * Copyright 2022 AMRC
  */
 
-import { h, render, createContext } from "https://esm.sh/preact";
+import { h, render, createContext } 
+                    from "https://esm.sh/preact@10.19.2";
 import { useContext, useEffect, useRef, useState }
-                                    from "https://esm.sh/preact/hooks";
-import { signal }                   from "https://esm.sh/@preact/signals";
-import htm                          from "https://esm.sh/htm";
-import yaml                         from "https://esm.sh/yaml";
+                    from "https://esm.sh/preact@10.19.2/hooks";
+import { signal }   from "https://esm.sh/@preact/signals@1.2.2";
+import htm          from "https://esm.sh/htm@3.1.1";
+import yaml         from "https://esm.sh/yaml@2.3.4";
 
 const html = htm.bind(h);
 

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -7,6 +7,7 @@
 import {h, render} from "https://unpkg.com/preact@latest?module";
 import {useEffect, useRef, useState} from "https://unpkg.com/preact@latest/hooks/dist/hooks.module.js?module";
 import htm from "https://unpkg.com/htm?module";
+import yaml from "https://unpkg.com/yaml/browser/index.js";
 
 const html = htm.bind(h);
 
@@ -363,7 +364,8 @@ function Conf(props) {
         if (!editbox.current) return;
         const new_conf = editbox.current.value;
 
-        const st = await put_string(`app/${app}/object/${obj}`, new_conf);
+        const json = yaml.parse(new_conf);
+        const st = await put_json(`app/${app}/object/${obj}`, json);
         if (st_ok(st)) {
             set_msg(html`Config updated`);
         } else {
@@ -377,7 +379,7 @@ function Conf(props) {
         }
     };
 
-    const json = JSON.stringify(conf, null, 4);
+    const json = yaml.stringify(conf);
     return html`
         <textarea ref=${editbox} cols=80 rows=25 value=${json}/><br/>
         <button onClick=${update}>Update</button>

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -370,7 +370,7 @@ function App(props) {
                 <${NewConf} update=${update} app=${app}/><//>
             ${objs.map(o => html`
                 <${Opener} key=${o} obj=${o} with_class=${true}>
-                    <${Conf} app=${app} obj=${o}/>
+                    <${Conf} app=${app} obj=${o} update_parent=${update}/>
                 <//>
             `)}
         </dl>
@@ -378,7 +378,7 @@ function App(props) {
 }
 
 function Conf(props) {
-    const {app, obj} = props;
+    const {app, obj, update_parent} = props;
 
     const [conf, set_conf] = useState("...");
     const [msg, set_msg] = useState("");
@@ -408,6 +408,7 @@ function Conf(props) {
         if (!await delete_path(`app/${app}/object/${obj}`)) {
             set_msg("Error deleting config.");
         }
+        update_parent();
     };
 
     const json = format.stringify(conf, null, 4);

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -361,11 +361,13 @@ function App(props) {
     const {app} = props;
     const [objs, set_objs] = useState([]);
 
-    useEffect(async () => set_objs(await fetch_json(`app/${app}/object`)), []);
+    const update = async () => set_objs(await fetch_json(`app/${app}/object`));
+    useEffect(update, []);
 
     return html`
         <dl>
-            <${Opener} title="New config"><${NewConf} app=${app}/><//>
+            <${Opener} title="New config">
+                <${NewConf} update=${update} app=${app}/><//>
             ${objs.map(o => html`
                 <${Opener} key=${o} obj=${o} with_class=${true}>
                     <${Conf} app=${app} obj=${o}/>
@@ -418,7 +420,7 @@ function Conf(props) {
 }
 
 function NewConf(props) {
-    const app = props.app;
+    const { app, update } = props;
     const [msg, set_msg] = useState("");
 
     const format = useContext(Formatter).value;
@@ -432,7 +434,15 @@ function NewConf(props) {
         const st = await put_json(
             `app/${app}/object/${new_obj.current.value}`,
             json);
-        set_msg(st_ok(st) ? "Create succeeded" : `Create failed: ${st}`);
+        if (st_ok(st)) {
+            await update();
+            set_msg("Create succeeded");
+            new_obj.current.value = "";
+            new_conf.current.value = "";
+        }
+        else {
+            set_msg(`Create failed: ${st}`);
+        }
     };
 
     return html`

--- a/editor/index.html
+++ b/editor/index.html
@@ -9,6 +9,11 @@
     <head>
         <title>ACS | Config Store</title>
         <script type=module src="editor.js"></script>
+        <style type="text/css">
+            textarea {
+                white-space: pre;
+            }
+        </style>
     </head>
     <body>
         <h1>Loading...</h1>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-configdb",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "The Config Store component of the AMRC Connectivity Stack",
   "author": "AMRC",
   "license": "MIT",


### PR DESCRIPTION
The new applications required by the Edge Cluster manager are horrible to try and edit in JSON. Support YAML in the config entry editor boxes.